### PR TITLE
Making valued options passable as parameters to grunt as well

### DIFF
--- a/tasks/lib/builder.js
+++ b/tasks/lib/builder.js
@@ -168,6 +168,8 @@ exports.init = function(grunt) {
     _.each(valued, function(value, key) {
       if(config[key]) {
         options.push('--'+value+' '+config[key]);
+      } else if (grunt.option(value)) {
+        options.push('--'+value+' '+grunt.option(value));
       }
     });
     return options;

--- a/tasks/lib/builder.js
+++ b/tasks/lib/builder.js
@@ -166,10 +166,10 @@ exports.init = function(grunt) {
     var options = [];
 
     _.each(valued, function(value, key) {
-      if(config[key]) {
-        options.push('--'+value+' '+config[key]);
-      } else if (grunt.option(value)) {
+      if (grunt.option(value)) {
         options.push('--'+value+' '+grunt.option(value));
+      } else if(config[key]) {
+        options.push('--'+value+' '+config[key]);
       }
     });
     return options;


### PR DESCRIPTION
It would be great if one could pass phpunit options with values as parameters to grunt as well, like:

``` bash
grunt phpunit --filter MyFilter
```

This pull request adds that feature, which makes it more convenient while developing e.g. because you can use the filter parameter to only include the tests you're currently working with.

Regards
