### PR TITLE
Fix #19 : coverageText and unquoted options

### DIFF
--- a/tasks/lib/builder.js
+++ b/tasks/lib/builder.js
@@ -101,6 +101,7 @@ exports.init = function(grunt) {
     logJunit: 'log-junit',
     logTap: 'log-tap',
     logJson: 'log-json',
+    coverageText: 'coverage-text',
     coverageHtml: 'coverage-html',
     coverageClover: 'coverage-clover',
     coveragePhp: 'coverage-php',
@@ -169,7 +170,7 @@ exports.init = function(grunt) {
       if (grunt.option(value)) {
         options.push('--'+value+' '+grunt.option(value));
       } else if(config[key]) {
-        options.push('--'+value+' '+config[key]);
+        options.push('--'+value+'="'+config[key]+'"');
       }
     });
     return options;


### PR DESCRIPTION
This fixes the `coverageText` not being considered a `valuedOption`. It also changes the valued options output from `--option value` to `--option="value"`. Both work but the second one is safer and avoid common errors with spaces and stuff in the option's value.

``` js
coverage: {
    options: {
        coverageText: 'app/tests/coverage.txt',
    }
}
```
