### PR TITLE
Added STDERR output logging when followOutput = true.

### DIFF
--- a/tasks/lib/phpunit.js
+++ b/tasks/lib/phpunit.js
@@ -39,6 +39,10 @@ exports.init = function(grunt) {
       term.stdout.on('data', function(data) {
         grunt.log.write(data);
       });
+
+      term.stderr.on('data', function(data) {
+        grunt.log.error(data);
+      });
     }
   };
 


### PR DESCRIPTION
Hi,

This is a short PR to add STDERR output logging when followOutput is set to true.

At the moment, any error happening during the tests will be silently ignored, which is generally not good.
