### PR TITLE
Set options per target

### DIFF
--- a/tasks/phpunit.js
+++ b/tasks/phpunit.js
@@ -16,14 +16,25 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask( 'phpunit', 'Run phpunit', function() {
 
-    var command = builder.build(this.data.dir, this.options);
-    var dir     = builder.directory();
-    var config  = builder.config();
+    var directory = this.data.dir || '';
 
-    grunt.log.writeln('Starting phpunit (target: ' + this.target.cyan + ') in ' + dir.cyan);
+    delete this.data.dir;
+    var options = this.options(this.data);
+
+    var command = builder.build(directory, function(config) {
+      // Merge task options with global options
+      Object.keys(options).forEach(function(key) {
+        config[key] = options[key];
+      });
+
+      return config;
+    });
+
+    // Run the command
+    grunt.log.writeln('Starting phpunit (target: ' + this.target.cyan + ') in ' + builder.directory().cyan);
     grunt.verbose.writeln('Exec: ' + command);
 
-    phpunit.run(command, this.async(), config);
+    phpunit.run(command, this.async(), builder.config());
   });
 
 };


### PR DESCRIPTION
I needed the ability for targets to set or override those of the options object. For example:

```
phpunit: {
    options: {
        bin: 'vendor/bin/phpunit',
        configuration: 'phpunit.xml'
    },
    local: {
        coverage: true
    },
    ci: {
        coverageClover: 'build/coverage.xml'
    }
}
```

I wanted to submit a quick PR just to see whether I was going about this correct (is there a current way to do this?) and whether you would accept a PR fixing this.

Thanks for the library!
