### PR TITLE
Add failOnfailures option to fail grunt trask instead of aborting grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,11 @@ Type: `Boolean` Default: `false`
 
 Prints the output to the console immediately, instead of displaying the whole ouput at the end.
 This can be useful -combining with debug: true- when there are many long running tests.
+
+####failOnFailures
+Type: `Boolean` Default: `false`
+
+Phpunit will return with exit code 1 when there are failed tests and wit exit code 2 when there are errors, and grunt will abort in this cases.
+When you want the task finish without aborting set failOnFailures to true.
+
+

--- a/tasks/lib/builder.js
+++ b/tasks/lib/builder.js
@@ -59,7 +59,8 @@ exports.init = function(grunt) {
     noConfiguration: false,
     includePath: false,
     d: false,
-    followOutput: false
+    followOutput: false,
+    failOnFailures: false
   };
 
   /**

--- a/tasks/lib/phpunit.js
+++ b/tasks/lib/phpunit.js
@@ -29,10 +29,20 @@ exports.init = function(grunt) {
         grunt.log.write(stdout);
       }
 
+
       if (err) {
-        grunt.fatal(err);
+        if(err.code === 1 || err.code === 2) {
+          if(config.failOnFailures) {
+            callback(false);
+          } else {
+            grunt.fatal(err);
+          }
+        } else {
+          grunt.fatal(err);
+        }
+      } else {
+        callback();
       }
-      callback();
     });
 
     if (config.followOutput) {


### PR DESCRIPTION
When there are failed tests phpunit will return with exit code 1, but we
shouldn't abort grunt in this case
