### PR TITLE
Append an `execMaxBuffer` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,4 +253,4 @@ Type: `Integer` Default: `200*1024`
 Configure the Node JS `maxBuffer` option passed to the 
 [`exec`](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) function. 
 This can be useful if you need to run a large test suite which outputs lot of logs, otherwise you could encounter a 
-`Fatal error: stdout maxBuffer exceeded.` error. See issue #29 for more informations about this.
+`Fatal error: stdout maxBuffer exceeded.` error. See issue [#29](https://github.com/SaschaGalley/grunt-phpunit/issues/29) for more informations about this.

--- a/README.md
+++ b/README.md
@@ -247,4 +247,10 @@ Type: `Boolean` Default: `false`
 Phpunit will return with exit code 1 when there are failed tests and wit exit code 2 when there are errors, and grunt will abort in this cases.
 When you want the task finish without aborting set failOnFailures to true.
 
+####execMaxBuffer
+Type: `Integer` Default: `200*1024`
 
+Configure the Node JS `maxBuffer` option passed to the 
+[`exec`](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) function. 
+This can be useful if you need to run a large test suite which outputs lot of logs, otherwise you could encounter a 
+`Fatal error: stdout maxBuffer exceeded.` error. See issue #29 for more informations about this.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git://github.com/SaschaGalley/grunt-phpunit.git"
   },
-  "version": "0.3.4",
+  "version": "0.3.5",
   "contributors": [{
     "name": "James Cryer",
     "email": "chat@jamescryer.com",

--- a/tasks/lib/builder.js
+++ b/tasks/lib/builder.js
@@ -60,7 +60,12 @@ exports.init = function(grunt) {
     includePath: false,
     d: false,
     followOutput: false,
-    failOnFailures: false
+    failOnFailures: false,
+    
+    // See NodeJS exec options 
+    // http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
+    execMaxBuffer: 200*1024
+
   };
 
   /**

--- a/tasks/lib/phpunit.js
+++ b/tasks/lib/phpunit.js
@@ -23,7 +23,7 @@ exports.init = function(grunt) {
    */
   exports.run = function(command, callback, config) {
 
-    var term = exec(command, function(err, stdout, stderr) {
+    var term = exec(command, {maxBuffer: config.execMaxBuffer}, function(err, stdout, stderr) {
 
       if (stdout && !config.followOutput) {
         grunt.log.write(stdout);


### PR DESCRIPTION
Append an `execMaxBuffer` option used to configure the `maxBuffer` option passed to the NodeJS `exec` command.

This PR fixes issue https://github.com/SaschaGalley/grunt-phpunit/issues/29.
