### PR TITLE
Fix d option to override php.ini settings (org issue #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# grunt-phpunit
+# grunt-phpunit-D+
 
 > Grunt plugin for running phpunit.
+It's a fork of [grunt-phpunit](https://github.com/SaschaGalley/grunt-phpunit) with enhanced possibilities for the 'd' options.
 
 ##Getting Started
 
@@ -11,7 +12,7 @@ If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out th
 1. Install this grunt plugin with the following command:
 
 	```shell
-	npm install grunt-phpunit --save-dev
+	npm install grunt-phpunit-dplus --save-dev
 	```
 
 

--- a/package.json
+++ b/package.json
@@ -1,22 +1,12 @@
 {
-  "name": "grunt-phpunit",
+  "name": "grunt-phpunit-dplus",
   "description": "Grunt plugin for running phpunit.",
-  "homepage": "https://github.com/SaschaGalley/grunt-phpunit",
-  "author": {
-    "name": "Sascha Galley",
-    "email": "me@xash.at",
-    "url": "http://xash.at/"
-  },
+  "author": "Michael Büttner <michbuett@gmx.de>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/SaschaGalley/grunt-phpunit.git"
+    "url": "git://github.com/michbuett/grunt-phpunit.git"
   },
-  "version": "0.3.6",
-  "contributors": [{
-    "name": "James Cryer",
-    "email": "chat@jamescryer.com",
-    "url": "http://www.jamescryer.com/"
-  }],
+  "version": "0.4.0",
   "main": "Gruntfile.js",
   "engines": {
     "node": "0.10.x"

--- a/tasks/lib/builder.js
+++ b/tasks/lib/builder.js
@@ -58,11 +58,10 @@ exports.init = function(grunt) {
     staticBackup: false,
     noConfiguration: false,
     includePath: false,
-    d: false,
     followOutput: false,
     failOnFailures: false,
-    
-    // See NodeJS exec options 
+
+    // See NodeJS exec options
     // http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
     execMaxBuffer: 200*1024
 
@@ -119,8 +118,7 @@ exports.init = function(grunt) {
     loader: 'loader',
     printer: 'printer',
     repeat: 'repeat',
-    includePath: 'include-path',
-    d: 'd'
+    includePath: 'include-path'
   };
 
   /**
@@ -183,6 +181,21 @@ exports.init = function(grunt) {
   };
 
   /**
+   * Builds options for the php.ini settings
+   *
+   * @return array
+   */
+  var buildDOptions = function() {
+
+    var options = [];
+
+    _.each(config.d, function(value, key) {
+      options.push('-d '+key+'='+value);
+    });
+    return options;
+  };
+
+  /**
    * Builds phpunit command
    *
    * @return string
@@ -192,7 +205,8 @@ exports.init = function(grunt) {
     var options = [].concat(
       buildFlagOptions(),
       buildFileOptions(),
-      buildValuedOptions()
+      buildValuedOptions(),
+      buildDOptions()
     );
     return options.join(' ');
   };


### PR DESCRIPTION
This allows to set php.ini settings using the d option, e.g.:

``` js
options: {
  d: {
    'error_reporting': 'E_ALL',
    ...
  }
}
```
