### PR TITLE
added passing of options to exec of phpunit

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,26 @@ When you want the task finish without aborting set failOnFailures to true.
 ####execMaxBuffer
 Type: `Integer` Default: `200*1024`
 
-Configure the Node JS `maxBuffer` option passed to the 
-[`exec`](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) function. 
-This can be useful if you need to run a large test suite which outputs lot of logs, otherwise you could encounter a 
+Configure the Node JS `maxBuffer` option passed to the
+[`exec`](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) function.
+This can be useful if you need to run a large test suite which outputs lot of logs, otherwise you could encounter a
 `Fatal error: stdout maxBuffer exceeded.` error. See issue [#29](https://github.com/SaschaGalley/grunt-phpunit/issues/29) for more informations about this.
+
+####execCwd
+Type: `String` Default: ``
+
+Current working directory of the child process
+
+####execEnv
+Type: `Object` Default: `{}`
+
+Object Environment key-value pairs
+
+####execEncoding
+Type: `String` Default: `utf8`
+
+####execTimeout
+Type: `Number` Default: 0
+
+####execKillSignal
+Type: `String` Default: `SIGTERM`

--- a/tasks/lib/phpunit.js
+++ b/tasks/lib/phpunit.js
@@ -23,7 +23,25 @@ exports.init = function(grunt) {
    */
   exports.run = function(command, callback, config) {
 
-    var term = exec(command, {maxBuffer: config.execMaxBuffer}, function(err, stdout, stderr) {
+    var cmdCommands = {
+      cwd : "",
+      env : {},
+      encoding : 'utf8',
+      timeout : 0,
+      maxBuffer: 200*1024,
+      killSignal : "SIGTERM"
+    };
+
+    Object.keys(cmdCommands).forEach(function(key) {
+      var configKey = "exec" + key.charAt(0).toUpperCase() + key.slice(1);
+      if (config[configKey]) {
+        cmdCommands[key] = config[configKey];
+      } else {
+        delete cmdCommands[key];
+      }
+    });
+
+    var term = exec(command, cmdCommands, function(err, stdout, stderr) {
 
       if (stdout && !config.followOutput) {
         grunt.log.write(stdout);


### PR DESCRIPTION
We needed a way to get more control over the child_process execution of phpunit. The syntax is compatible to execMaxBuffer, and all other parameters are using the same syntax
